### PR TITLE
Agregar campo de imagen de Producto

### DIFF
--- a/.env
+++ b/.env
@@ -2,7 +2,7 @@ APP_NAME="Granos de Oro"
 APP_ENV=local
 APP_KEY=base64:JwUe0s3aPvPWu+M99oRbJckUsQATi/SPMNOmjyHN3BE=
 APP_DEBUG=true
-APP_URL=http://localhost
+APP_URL=http://127.0.0.1:8000
 
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null

--- a/.envDev
+++ b/.envDev
@@ -2,7 +2,7 @@ APP_NAME="Granos de Oro"
 APP_ENV=local
 APP_KEY=base64:JwUe0s3aPvPWu+M99oRbJckUsQATi/SPMNOmjyHN3BE=
 APP_DEBUG=true
-APP_URL=http://localhost
+APP_URL=http://127.0.0.1:8000
 
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null

--- a/app/Filament/Resources/ProductoResource.php
+++ b/app/Filament/Resources/ProductoResource.php
@@ -6,11 +6,13 @@ use App\Filament\Resources\ProductoResource\Pages;
 use App\Filament\Resources\ProductoResource\RelationManagers;
 use App\Models\Producto;
 use Filament\Forms;
+use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
+use Filament\Tables\Columns\ImageColumn;
 use Filament\Tables\Columns\Layout\Panel;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
@@ -45,6 +47,11 @@ class ProductoResource extends Resource
                 ->required()
                 ->numeric()
                 ->minValue(1),
+            FileUpload::make('imagen')
+                ->label('Imagen del producto')
+                ->image()
+                ->directory('productos')
+                ->required(),
             ]);
     }
 
@@ -57,6 +64,7 @@ class ProductoResource extends Resource
                 TextColumn::make('descripcion')->sortable()->label('Descripción'),
                 TextColumn::make('precio')->sortable()->label('Precio'),
                 TextColumn::make('cantidad_en_existencia')->sortable()->label('Cantidad en existencia'),
+                ImageColumn::make('imagen')->label('Imagen')->sortable(),
                 
             ])
             ->filters([

--- a/app/Models/Producto.php
+++ b/app/Models/Producto.php
@@ -9,7 +9,7 @@ class Producto extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['nombre', 'descripcion', 'precio', 'cantidad_en_existencia'];
+    protected $fillable = ['nombre', 'descripcion', 'precio', 'cantidad_en_existencia', 'imagen'];
 
     public function detallesPedidos()
     {

--- a/database/migrations/2024_06_19_034021_create_productos_table.php
+++ b/database/migrations/2024_06_19_034021_create_productos_table.php
@@ -17,6 +17,7 @@ return new class extends Migration
             $table->text('descripcion')->nullable();
             $table->decimal('precio', 10, 2);
             $table->integer('cantidad_en_existencia');
+            $table->string('imagen');
             $table->timestamps();
         });
     }


### PR DESCRIPTION
Se añadio la imagen la base de datos para productos, se modifico el modelo de productos y el formulario para que funcionara correctamente, la imagen se guarda en la ruta de Storage/app/public/productos, y se ejecuto el comando de `php artisan storage:link` para conectar el public con staorage para poder acceder a las imagenes , tambein se modificarion las variables de entorno para que pueda mostrar las imágenes de donde se esta ejecutando el contenedor con su localhost y puerto  