### PR TITLE
Actualizar  Pedido y Producto para incluir el campo 'precio_unitario'

### DIFF
--- a/app/Filament/Resources/CompradorResource.php
+++ b/app/Filament/Resources/CompradorResource.php
@@ -17,7 +17,7 @@ class CompradorResource extends Resource
     protected static ?string $navigationGroup = 'Administrador';
     protected static ?string $navigationLabel = 'Compradores';
     
-    protected static ?int $navigationSort = 2;
+    protected static ?int $navigationSort = 3;
     protected static ?string $navigationIcon = 'heroicon-s-identification';
 
     public static function form(Form $form): Form

--- a/app/Filament/Resources/PedidoResource.php
+++ b/app/Filament/Resources/PedidoResource.php
@@ -52,7 +52,15 @@ class PedidoResource extends Resource
                             ->label('Producto')
                             ->options(Producto::all()->pluck('nombre', 'id'))
                             ->reactive()
-                            ->required(),
+                            ->required()
+                            ->afterStateUpdated(function ($state, callable $set) {
+                                if ($state) {
+                                    $producto = Producto::find($state);
+                                    if ($producto) {
+                                        $set('precio_unitario', $producto->precio);
+                                    }
+                                }
+                            }),
                         TextInput::make('cantidad')
                             ->numeric()
                             ->minValue(1)
@@ -63,9 +71,17 @@ class PedidoResource extends Resource
                             ->label('Cantidad')
                             ->required()
                             ->reactive(),
+                        TextInput::make('precio_unitario')
+                            ->label('Precio Unitario')
+                            ->disabled()
+                            ->dehydrated(true)
+                            ->numeric()
+                            ->required(),
                     ])
                     ->minItems(1)
+                    ->maxItems(50)
                     ->label('Productos')
+                    ->relationship('detallesPedidos')
                     ->columns(2)
                     ->afterStateUpdated(function (callable $set, callable $get) {
                         $detallesPedidos = $get('detallesPedidos') ?? [];

--- a/app/Filament/Resources/PedidoResource/Pages/CreatePedido.php
+++ b/app/Filament/Resources/PedidoResource/Pages/CreatePedido.php
@@ -45,9 +45,10 @@ class CreatePedido extends CreateRecord
                             'id_pedido' => $pedido->id,
                             'id_producto' => $detalle['id_producto'],
                             'cantidad' => $detalle['cantidad'],
+                            'precio_unitario' => $productoModel->precio // Guardamos el precio actual
                         ]);
                     } else {
-                        $errores[] = "No hay suficiente cantidad en existencia para el producto: {$productoModel->nombre}. Cantidad actual: {$productoModel->cantidad_en_existencia}, Cantidad solicitada: {$detalle['cantidad']}";
+                        $errores[] = "No hay suficiente cantidad en existencia para el producto: {$productoModel->nombre}";
                     }
                 } else {
                     $errores[] = "Producto no encontrado: ID {$detalle['id_producto']}";
@@ -56,7 +57,6 @@ class CreatePedido extends CreateRecord
         }
     
         if (!empty($errores)) {
-            // Si hay errores, eliminamos el pedido creado y lanzamos una excepción
             $pedido->delete();
             throw new \Exception(implode("\n", $errores));
         }

--- a/app/Filament/Resources/ProductoResource.php
+++ b/app/Filament/Resources/ProductoResource.php
@@ -25,7 +25,7 @@ class ProductoResource extends Resource
     protected static ?string $navigationGroup = 'Administrador';
 
     protected static ?string $navigationIcon = 'heroicon-s-tag';
-    protected static ?int $navigationSort = 3;
+    protected static ?int $navigationSort = 2;
 
     public static function form(Form $form): Form
     {

--- a/app/Models/DetallePedido.php
+++ b/app/Models/DetallePedido.php
@@ -13,7 +13,8 @@ class DetallePedido extends Model
     protected $fillable = [
         'id_pedido',
         'id_producto',
-        'cantidad'
+        'cantidad',
+        'precio_unitario'
     ];
 
     public function pedido()
@@ -25,4 +26,5 @@ class DetallePedido extends Model
     {
         return $this->belongsTo(Producto::class, 'id_producto');
     }
+    
 }

--- a/database/migrations/2024_06_19_034143_create_detalle_pedidos_table.php
+++ b/database/migrations/2024_06_19_034143_create_detalle_pedidos_table.php
@@ -15,6 +15,7 @@ return new class extends Migration
             $table->unsignedBigInteger('id_pedido');
             $table->unsignedBigInteger('id_producto');
             $table->integer('cantidad');
+            $table->decimal('precio_unitario', 10, 2);
             $table->timestamps();
     
             $table->foreign('id_pedido')->references('id')->on('pedidos')->onDelete('cascade');


### PR DESCRIPTION
Se añadió el campo de precio_unitario en la tabla detalle_pedido para almacenar el valor de producto a la hora de hacer el pedido para tener un mejor manejo de los datos, también se modificaron los modelos, y los formularios para su funcionamiento 